### PR TITLE
Fix two problems

### DIFF
--- a/goforever.go
+++ b/goforever.go
@@ -140,7 +140,7 @@ func host() string {
 	if isHttps() == false {
 		scheme = "http"
 	}
-	return fmt.Sprintf("%s://%s:%s@0.0:%s",
+	return fmt.Sprintf("%s://%s:%s@0.0.0.0:%s",
 		scheme, config.Username, config.Password, config.Port,
 	)
 }

--- a/http_test.go
+++ b/http_test.go
@@ -55,6 +55,6 @@ func newTestResponse(method string, path string, body io.Reader) ([]byte, *http.
 	ts := httptest.NewServer(http.HandlerFunc(Handler))
 	defer ts.Close()
 	url := ts.URL + path
-	b, r, _ := greq.Do(method, url, body)
+	b, r, _ := greq.Do(method, url, nil, body)
 	return b, r
 }


### PR DESCRIPTION
In separate commits, I've addressed two problems:

1. The self test fails because of an error in http_test.go (API mismatch to greq)
2. The CLI program doesn't work at all on Solaris/illumos systems because 0.0 is not a valid IP address.

(Note that I'd actually recommend using 127.0.0.1 or even a UNIX domain socket to further lock down security.)