### PR TITLE
Change IP bind

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ import (
 )
 
 type Config struct {
+	IP        string
 	Port      string
 	Username  string
 	Password  string

--- a/goforever.go
+++ b/goforever.go
@@ -134,7 +134,7 @@ func setConfig() {
 		config.Port = "2224"
 	}
 	if config.IP == "" {
-		config.IP = "127.0.0.1"
+		config.IP = "0.0.0.0"
 	}
 }
 

--- a/goforever.go
+++ b/goforever.go
@@ -133,6 +133,9 @@ func setConfig() {
 	if config.Port == "" {
 		config.Port = "2224"
 	}
+	if config.IP == "" {
+		config.IP = "127.0.0.1"
+	}
 }
 
 func host() string {

--- a/goforever.toml
+++ b/goforever.toml
@@ -1,3 +1,4 @@
+ip = "127.0.0.1"
 port = "2224"
 username = "go"
 password = "forever"

--- a/http.go
+++ b/http.go
@@ -18,11 +18,11 @@ func HttpServer() {
 	http.HandleFunc("/", AuthHandler(Handler))
 	fmt.Printf("goforever serving port %s\n", config.Port)
 	if isHttps() == false {
-		http.ListenAndServe(fmt.Sprintf(":%s", config.Port), nil)
+		http.ListenAndServe(fmt.Sprintf("%s:%s", config.IP, config.Port), nil)
 		return
 	}
 	log.Printf("SSL enabled.\n")
-	http.ListenAndServeTLS(fmt.Sprintf(":%s", config.Port), "cert.pem", "key.pem", nil)
+	http.ListenAndServeTLS(fmt.Sprintf("%s:%s", config.IP, config.Port), "cert.pem", "key.pem", nil)
 }
 
 func isHttps() bool {

--- a/http.go
+++ b/http.go
@@ -17,12 +17,18 @@ func HttpServer() {
 	http.HandleFunc("/favicon.ico", http.NotFound)
 	http.HandleFunc("/", AuthHandler(Handler))
 	fmt.Printf("goforever serving port %s\n", config.Port)
+	fmt.Printf("goforever serving IP %s\n", config.IP)
+	bindAddress := fmt.Sprintf("%s:%s", config.IP, config.Port)
 	if isHttps() == false {
-		http.ListenAndServe(fmt.Sprintf("%s:%s", config.IP, config.Port), nil)
+		if err := http.ListenAndServe(bindAddress, nil); err != nil {
+			log.Fatal("ListenAndServe: ", err)
+		}
 		return
 	}
 	log.Printf("SSL enabled.\n")
-	http.ListenAndServeTLS(fmt.Sprintf("%s:%s", config.IP, config.Port), "cert.pem", "key.pem", nil)
+	if err := http.ListenAndServeTLS(bindAddress, "cert.pem", "key.pem", nil); err != nil {
+		log.Fatal("ListenAndServeTLS: ", err)
+	}
 }
 
 func isHttps() bool {


### PR DESCRIPTION
Permit user to define which ip address to bind through the toml configuration file.

Eg.:

```
ip = "127.0.0.1"
port = "2224"
username = "go"
password = "forever"
pidfile = "goforever.pid"
logfile = "goforever.log"
errfile = "goforever.log" 
```

If not possible to bind to the specified IP, the program will abort and log a message like:

```
2015/11/09 23:19:21 ListenAndServe: listen tcp 11.22.33.44:2224: bind: cannot assign requested address
```

The default bind address will be **0.0.0.0:2224**, maintaining the same behavior as before.
